### PR TITLE
Allow users to pass in broken down budgets and return the broken down values

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,13 @@ performanceBudget({budget: {
       "percentage": 4
     }
   },
-  "budget": 3000,
+  "budget": {
+    "total": 9000,
+    "css": 2000,
+    "images": 400,
+    "js": 400,
+    "fonts": 200
+  },
   "totalSize": 3721,
   "remainingBudget": -721
 }

--- a/README.md
+++ b/README.md
@@ -54,12 +54,19 @@ For a different file location pass the location as a parameter into performanceB
 performanceBudget({dest: '/new-folder/performance-budget.json'})
 ```
 
-To define a personal budget you can pass the max file size as a parameter into performanceBudget.
+To define a personal budget for the total budget, or broken down based on file type, or both, you can pass the max file size as a parameter into performanceBudget.
 The file size input has to be a number and in bytes. If no file size is passed through it will
 default to 1400000 (1.4Mb).
 
 ```javascript
-performanceBudget({budget: 100000})
+performanceBudget({budget: {
+  'total': 9000,
+  'css': 2000,
+  'images': 400,
+  'js': 400,
+  'fonts': 200
+  }
+})
 ```
 
 ###Example of output

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ var fonts = 'fonts';
 var svg = 'svg';
 
 var totalFileSize;
+var cssFileSize;
+var imagesFileSize;
+var jsFileSize;
+var fontsFileSize;
 
 var defaultTotalBudget = 1400000;
 var defaultCssBudget = 300;
@@ -38,6 +42,10 @@ function performanceBudget (options) {
   perfObj = {};
   perfObj['fileTypes'] = {};
   totalFileSize = 0;
+  var cssFileSize = 0;
+  var imagesFileSize = 0;
+  var jsFileSize = 0;
+  var fontsFileSize = 0;
   var options = extend({}, options);
 
   function checkIfDestIsDefined () {
@@ -94,6 +102,19 @@ function performanceBudget (options) {
     }
     perfObj.fileTypes[extname].files.push({file: currentFile.path, size: fileSize});
 
+    if(extname === 'css') {
+      cssFileSize += fileSize;
+    }
+    if(extname === 'images') {
+      imagesFileSize += fileSize;
+    }
+    if(extname === 'js') {
+      jsFileSize += fileSize;
+    }
+    if(extname === 'fonts') {
+      fontsFileSize += fileSize;
+    }
+
   }
 
   function whichSvg (extname, type) {
@@ -133,12 +154,17 @@ function performanceBudget (options) {
   }
 
   function pushTotalFileSizeToJson () {
-    perfObj['totalSize'] = totalFileSize;
+    perfObj.totalSizes = {};
+    perfObj.totalSizes.totalSize = totalFileSize;
+    perfObj.totalSizes.css = cssFileSize;
+    perfObj.totalSizes.images = imagesFileSize;
+    perfObj.totalSizes.js = jsFileSize;
+    perfObj.totalSizes.fonts = fontsFileSize;
   }
 
   function calculatePercentageForEachFileType () {
     for(var item in perfObj.fileTypes) {
-      var percentage = Math.round((perfObj.fileTypes[item].total / perfObj.totalSize) * 100);
+      var percentage = Math.round((perfObj.fileTypes[item].total / perfObj.totalSizes.totalSize) * 100);
       perfObj.fileTypes[item]['percentage'] = percentage;
     } 
   }
@@ -176,7 +202,12 @@ function performanceBudget (options) {
   }
 
   function addRemainingBudgetToJsonFile () {
-    perfObj['remainingBudget'] = perfObj.budget.total - perfObj.totalSize;
+    perfObj.remainingBudget = {};
+    perfObj.remainingBudget.total = perfObj.budget.total - perfObj.totalSizes.totalSize;
+    perfObj.remainingBudget.css = perfObj.budget.css - perfObj.totalSizes.css;
+    perfObj.remainingBudget.images = perfObj.budget.images - perfObj.totalSizes.images;
+    perfObj.remainingBudget.js = perfObj.budget.js - perfObj.totalSizes.js;
+    perfObj.remainingBudget.fonts = perfObj.budget.fonts - perfObj.totalSizes.fonts;
   }
 
   function generate (file, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -136,20 +136,20 @@ function performanceBudget (options) {
     for(var item in perfObj.fileTypes) {
       var percentage = Math.round((perfObj.fileTypes[item].total / perfObj.totalSize) * 100);
       perfObj.fileTypes[item]['percentage'] = percentage;
-    }
+    } 
   }
 
   function addBudgetToJsonFile () {
-    if (options.budget === undefined) {
-      options.budget = defaultBudget;
+    if (options.totalBudget === undefined) {
+      options.totalBudget = defaultBudget;
     }
 
-    if (perfObj.budget !== undefined) return;
-    perfObj['budget'] = options.budget;
-  }
+    if (perfObj.totalBudget !== undefined) return;
+      perfObj['totalBudget'] = options.totalBudget;
+    }
 
   function addRemainingBudgetToJsonFile () {
-    perfObj['remainingBudget'] = perfObj.budget - perfObj.totalSize;
+    perfObj['remainingBudget'] = perfObj.totalBudget - perfObj.totalSize;
   }
 
   function generate (file, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ var svg = 'svg';
 
 var totalFileSize;
 
-var defaultBudget = 1400000;
+var defaultTotalBudget = 1400000;
+var defaultCssBudget = 300;
+var defaultImagesBudget = 600;
+var defaultJsBudget = 200;
+var defaultFontsBudget = 300;
 var defaultFilePath = './performanceBudget.json';
 
 // Consts
@@ -140,16 +144,39 @@ function performanceBudget (options) {
   }
 
   function addBudgetToJsonFile () {
-    if (options.totalBudget === undefined) {
-      options.totalBudget = defaultBudget;
+    if (options.budget === undefined) {
+      options.budget = {};
+    }
+    if (options.budget.total === undefined) {
+      options.budget.total = defaultTotalBudget;
+    }
+    if (options.budget.css === undefined) {
+      options.budget.css = defaultCssBudget;
+    }
+    if (options.budget.images === undefined) {
+      options.budget.images = defaultImagesBudget;
+    }
+    if (options.budget.js === undefined) {
+      options.budget.js = defaultJsBudget;
+    }
+    if (options.budget.fonts === undefined) {
+      options.budget.fonts = defaultFontsBudget;
     }
 
-    if (perfObj.totalBudget !== undefined) return;
-      perfObj['totalBudget'] = options.totalBudget;
+    if ((options.budget.css + options.budget.images + options.budget.js + options.budget.fonts) > options.budget.total) {
+      // TODO better error message
+      throw new Error("The total budget size of the broken down assets is larger than the total budget");
     }
+
+    if (perfObj.budget !== undefined) {
+      return;
+    } else {
+      perfObj['budget'] = options.budget;
+    }
+  }
 
   function addRemainingBudgetToJsonFile () {
-    perfObj['remainingBudget'] = perfObj.totalBudget - perfObj.totalSize;
+    perfObj['remainingBudget'] = perfObj.budget.total - perfObj.totalSize;
   }
 
   function generate (file, enc, cb) {

--- a/performanceBudget.json
+++ b/performanceBudget.json
@@ -31,7 +31,13 @@
       "percentage": 16
     }
   },
-  "totalBudget": 1400000,
+  "budget": {
+    "total": 9000,
+    "css": 2000,
+    "images": 400,
+    "js": 400,
+    "fonts": 200
+  },
   "totalSize": 1266,
-  "remainingBudget": 1398734
+  "remainingBudget": 7734
 }

--- a/performanceBudget.json
+++ b/performanceBudget.json
@@ -38,6 +38,18 @@
     "js": 400,
     "fonts": 200
   },
-  "totalSize": 1266,
-  "remainingBudget": 7734
+  "totalSizes": {
+    "totalSize": 1266,
+    "css": 57,
+    "images": 1002,
+    "js": 207,
+    "fonts": 0
+  },
+  "remainingBudget": {
+    "total": 7734,
+    "css": 1943,
+    "images": -602,
+    "js": 193,
+    "fonts": 200
+  }
 }

--- a/performanceBudget.json
+++ b/performanceBudget.json
@@ -4,7 +4,7 @@
       "total": 1002,
       "files": [
         {
-          "file": "/Users/matthewmacartney/Development/Code/performance-budget/_src/totalFileSize/imgres-1.png",
+          "file": "/Users/JamesTudsbury/Documents/projects/performance-budget/_src/totalFileSize/imgres-1.png",
           "size": 1002
         }
       ],
@@ -14,7 +14,7 @@
       "total": 57,
       "files": [
         {
-          "file": "/Users/matthewmacartney/Development/Code/performance-budget/_src/totalFileSize/info.css",
+          "file": "/Users/JamesTudsbury/Documents/projects/performance-budget/_src/totalFileSize/info.css",
           "size": 57
         }
       ],
@@ -24,14 +24,14 @@
       "total": 207,
       "files": [
         {
-          "file": "/Users/matthewmacartney/Development/Code/performance-budget/_src/totalFileSize/test.js",
+          "file": "/Users/JamesTudsbury/Documents/projects/performance-budget/_src/totalFileSize/test.js",
           "size": 207
         }
       ],
       "percentage": 16
     }
   },
-  "budget": 1400000,
+  "totalBudget": 1400000,
   "totalSize": 1266,
   "remainingBudget": 1398734
 }

--- a/test/test.js
+++ b/test/test.js
@@ -183,13 +183,13 @@ describe('when running gulp-performance-budget', function () {
 
   it('should allow a user to pass through a budget which is added to the json file', function (done) {
     gulp.src(testSrc)
-      .pipe(performanceBudget({dest: jsonFileAll, totalBudget: 3000}))
+      .pipe(performanceBudget({dest: jsonFileAll, budget: {'total': 3000}}))
       .pipe(gulp.dest('dest'))
       .on('end', function (err, data) {
       fs.readFile(jsonFileAll, 'utf8', function (err, data) {
         if (err) throw (err);
         var dataObj = JSON.parse(data);
-        dataObj.totalBudget.should.eql(3000);
+        dataObj.budget.total.should.eql(3000);
         done();
       });
     });
@@ -197,15 +197,14 @@ describe('when running gulp-performance-budget', function () {
 
   it('should allow a user to pass through a budget which is added to the json file', function (done) {
     gulp.src(testTotalSizeSrc)
-      .pipe(performanceBudget({dest: jsonFileTotalSize, totalBudget: 3000}))
+      .pipe(performanceBudget({dest: jsonFileTotalSize, budget: {total: 3000}}))
       .pipe(gulp.dest('dest'))
       .on('end', function (err, data) {
       fs.readFile(jsonFileTotalSize, 'utf8', function (err, data) {
         if (err) throw (err);
         var dataObj = JSON.parse(data);
 
-        var remainingBudget = dataObj.totalBudget - dataObj.totalSize;
-        console.log("james" + remainingBudget);
+        var remainingBudget = dataObj.budget.total - dataObj.totalSize;
 
         dataObj.remainingBudget.should.eql(remainingBudget);
         done();
@@ -226,4 +225,32 @@ describe('when running gulp-performance-budget', function () {
       });
     });
   });
+
+  it('should allow a user to pass through a broken down budget which are added to the json file', function (done) {
+    gulp.src(testTotalSizeSrc)
+      .pipe(performanceBudget({
+        'budget': {
+          'total': 9000,
+          'css': 2000,
+          'images': 400,
+          'js': 400,
+          'fonts': 200
+        }
+      }))
+      .pipe(gulp.dest('dest'))
+      .on('end', function (err, data) {
+        fs.readFile(jsonFileTotalSize, 'utf8', function (err, data) {
+          if (err) throw (err);
+          var dataObj = JSON.parse(data);
+
+          dataObj.budget.total.should.eql(dataObj.budget.total);
+          dataObj.budget.css.should.eql(dataObj.budget.css);
+          dataObj.budget.images.should.eql(dataObj.budget.images);
+          dataObj.budget.js.should.eql(dataObj.budget.js);
+          dataObj.budget.fonts.should.eql(dataObj.budget.fonts);
+          done();
+        });
+      });
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -139,7 +139,7 @@ describe('when running gulp-performance-budget', function () {
       fs.readFile(jsonFileTotalSize, 'utf-8', function(err, data){
         if(err) throw (err);
         var dataObj = JSON.parse(data);
-        dataObj.should.have.property('totalSize').eql(total);
+        dataObj.totalSizes.should.have.property('totalSize').eql(total);
         done();
       })
     });
@@ -197,16 +197,16 @@ describe('when running gulp-performance-budget', function () {
 
   it('should allow a user to pass through a budget which is added to the json file', function (done) {
     gulp.src(testTotalSizeSrc)
-      .pipe(performanceBudget({dest: jsonFileTotalSize, budget: {total: 3000}}))
+      .pipe(performanceBudget({dest: jsonFileTotalSize, budget: {total: 9000}}))
       .pipe(gulp.dest('dest'))
       .on('end', function (err, data) {
       fs.readFile(jsonFileTotalSize, 'utf8', function (err, data) {
         if (err) throw (err);
         var dataObj = JSON.parse(data);
 
-        var remainingBudget = dataObj.budget.total - dataObj.totalSize;
+        var remainingBudget = dataObj.budget.total - dataObj.totalSizes.totalSize;
 
-        dataObj.remainingBudget.should.eql(remainingBudget);
+        dataObj.remainingBudget.total.should.eql(remainingBudget);
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -183,13 +183,13 @@ describe('when running gulp-performance-budget', function () {
 
   it('should allow a user to pass through a budget which is added to the json file', function (done) {
     gulp.src(testSrc)
-      .pipe(performanceBudget({dest: jsonFileAll, budget: 3000}))
+      .pipe(performanceBudget({dest: jsonFileAll, totalBudget: 3000}))
       .pipe(gulp.dest('dest'))
       .on('end', function (err, data) {
       fs.readFile(jsonFileAll, 'utf8', function (err, data) {
         if (err) throw (err);
         var dataObj = JSON.parse(data);
-        dataObj.budget.should.eql(3000);
+        dataObj.totalBudget.should.eql(3000);
         done();
       });
     });
@@ -197,14 +197,15 @@ describe('when running gulp-performance-budget', function () {
 
   it('should allow a user to pass through a budget which is added to the json file', function (done) {
     gulp.src(testTotalSizeSrc)
-      .pipe(performanceBudget({dest: jsonFileTotalSize, budget: 3000}))
+      .pipe(performanceBudget({dest: jsonFileTotalSize, totalBudget: 3000}))
       .pipe(gulp.dest('dest'))
       .on('end', function (err, data) {
       fs.readFile(jsonFileTotalSize, 'utf8', function (err, data) {
         if (err) throw (err);
         var dataObj = JSON.parse(data);
 
-        var remainingBudget = dataObj.budget - dataObj.totalSize;
+        var remainingBudget = dataObj.totalBudget - dataObj.totalSize;
+        console.log("james" + remainingBudget);
 
         dataObj.remainingBudget.should.eql(remainingBudget);
         done();


### PR DESCRIPTION
Allow a user to input broken down budgets based on file types, e.g. set a CSS budget.
Output the broken down budgets, broken down file sizes, and broken down remaining budgets per file type.