### PR TITLE
Refactor: Internal Promise API

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs-extra'));
 var path = require('path');
 var PluginError = require('plugin-error');
-var pathExists = require('path-exists');
 var extend = require('node.extend');
 
 var gulp = require('gulp');

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var path = require('path');
 var PluginError = require('plugin-error');
 var pathExists = require('path-exists');
 var extend = require('node.extend');
-// var mkpath = require('mkpath');
 
 var gulp = require('gulp');
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var PluginError = require('plugin-error');
 var pathExists = require('path-exists');
 var extend = require('node.extend');
-var mkpath = require('mkpath');
+// var mkpath = require('mkpath');
 
 var gulp = require('gulp');
 
@@ -48,10 +48,13 @@ function performanceBudget (options) {
 
   function writeToFile () {
     var pathStr = getPath(options.dest);
-    mkpath.sync(pathStr);
-    return fs.writeJsonAsync(options.dest, perfObj, function (err, data) {
-      if (err) throw (err);
-    });
+
+    return fs.ensureDirAsync(pathStr)
+      .then(function() {
+        return fs.writeJsonAsync(options.dest, perfObj, function (err, data) {
+          if (err) throw (err);
+        });
+      })
   };
 
   function getCurrentFileSizeInKB (file) {
@@ -70,9 +73,6 @@ function performanceBudget (options) {
     var fileSize = parseInt(getCurrentFileSizeInKB(file));
     totalFileSize += fileSize;
     if (!perfObj.fileTypes.hasOwnProperty (extname)) {
-
-      // console.log(extname);
-
       perfObj.fileTypes[extname] = { total: fileSize };
     } else {
       updateTotal(extname, fileSize);

--- a/index.js
+++ b/index.js
@@ -164,6 +164,11 @@ function performanceBudget (options) {
     perfObj['remainingBudget'] = perfObj.budget - perfObj.totalSize;
   }
 
+  function setCurrentFile(file) {
+    currentFile = file
+    return Promise.resolve();
+  }
+
   function generate (file, enc, cb) {
 
     if (file.isNull()) {
@@ -176,21 +181,19 @@ function performanceBudget (options) {
       return;
     };
 
-    currentFile = file;
+    return setCurrentFile(file)
+      .then(function() {
+        addBudgetToJsonFile();
+        checkIfDestIsDefined();
+        buildPerfObjects(getFileExtension(file), file);
+        pushTotalFileSizeToJson();
+        calculatePercentageForEachFileType();
+        addRemainingBudgetToJsonFile();
 
-    addBudgetToJsonFile();
-    checkIfDestIsDefined();
+        writeToFile();
 
-    // TODO these need promises to avoid race conditions;
-
-    buildPerfObjects(getFileExtension(file), file);
-    pushTotalFileSizeToJson();
-    calculatePercentageForEachFileType();
-    addRemainingBudgetToJsonFile();
-
-    writeToFile();
-
-    cb();
+        cb();
+      });
 
   };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "filesize": "^3.3.0",
     "fs-extra": "^0.29.0",
     "gulp": "^3.9.1",
-    "mkpath": "^1.0.0",
     "node.extend": "^1.1.5",
     "path-exists": "^2.1.0",
     "plugin-error": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.3.5",
+    "filesize": "^3.3.0",
     "fs-extra": "^0.29.0",
     "gulp": "^3.9.1",
     "mkpath": "^1.0.0",


### PR DESCRIPTION
This PR includes the following:

* Added `filesize` as a project dependency. It was erroring with module cannot be found before until this was added.
* I've moved the base functions to use Promise API.
* Removed the `mkdir` dependency and replaced it will `fs-extra`'s `ensureDir`

All tests are green after these changes.